### PR TITLE
Macro to run several commands

### DIFF
--- a/sh.janet
+++ b/sh.janet
@@ -215,6 +215,20 @@
   (def specs (collect-proc-specs args))
   (tuple run* ;specs))
 
+(defmacro prog
+  ``
+  Run shell commands in sequence.
+
+  Returns an array of exit codes.
+
+  Example: (sh/prog (pwd)
+                    (ls -a))
+  ``
+  [& args]
+  ~(mapcat array/peek
+    ,(map (fn [arg]
+      ~(sh/run* ,;(collect-proc-specs arg))) args)))
+
 (defn $?*
   ``
   A function version of `$?` that accepts a tuple or an array of strings.

--- a/test/sh.janet
+++ b/test/sh.janet
@@ -84,3 +84,9 @@
 
 (assert (= (sh/$<_ echo ;[1 2 3])
            "1 2 3"))
+
+(buffer/clear out-buf)
+(def prog-res (sh/prog (echo hello > ,out-buf)
+                       (echo bye >> ,out-buf)))
+(assert (all zero? prog-res))
+(assert (deep= out-buf @"hello\nbye\n"))


### PR DESCRIPTION
This patch adds the sh/prog macro which allows running several shell commands sequentially without having to either
a. put their commands in an array of strings (like in sh/run*)
b. have to type (sh/$ ...) several times
You can now just do
```
(sh/prog (pwd) (ls -a) ...)
```
