### PR TITLE
$< and $<_ dup stdout before any custom redirects

### DIFF
--- a/sh.janet
+++ b/sh.janet
@@ -277,7 +277,7 @@
   ``
   [& specs]
   (def out @"")
-  (def exit (run* ;(tuple/slice specs 0 -2) (tuple ;(last specs) :> out)))
+  (def exit (run* ;(tuple/slice specs 0 -2) (tuple :> out ;(last specs))))
   (unless (all zero? exit)
     (error (string/format emsg specs exit)))
   (string out))
@@ -304,7 +304,7 @@
   ``
   [& specs]
   (def out @"")
-  (def exit (run* ;(tuple/slice specs 0 -2) (tuple ;(last specs) :> out)))
+  (def exit (run* ;(tuple/slice specs 0 -2) (tuple :> out ;(last specs))))
   (unless (all zero? exit)
     (error (string/format emsg specs exit)))
   (defn should-trim? [c]

--- a/test/sh.janet
+++ b/test/sh.janet
@@ -84,3 +84,6 @@
 
 (assert (= (sh/$<_ echo ;[1 2 3])
            "1 2 3"))
+
+(assert (= (sh/$< sh -c "echo out; echo err >&2" > [stderr stdout])
+  "out\nerr\n"))


### PR DESCRIPTION
This allows capturing stdout and stderr with:

    (sh/$< command >[stderr stdout])