### PR TITLE
Add macros sh and sh< for running commands in a real shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The rationale and design is partially covered in a [blog post](https://acha.ninj
 
 ## Quick examples
 
-```
+```janet
 (import sh)
 
 # raise an error on failure.
@@ -25,4 +25,11 @@ The rationale and design is partially covered in a [blog post](https://acha.ninj
 (match (sh/run yes | head -n5)
   [0 0] :ok)
 
+# run a command in a real shell (your system's `sh`)
+(sh/sh cd /tmp && git clone https://github.com/andrewchambers/janet-sh)
+
+# use shell variables in a real shell
+(sh/sh<
+  if [ "${USER}" = ,(os/getenv "USER") ];
+  then echo "it's \"me\""; else echo "not me"; fi)
 ```

--- a/test/sh.janet
+++ b/test/sh.janet
@@ -87,3 +87,15 @@
 
 (assert (= (sh/$< sh -c "echo out; echo err >&2" > [stderr stdout])
   "out\nerr\n"))
+
+(assert (= (sh/sh cd /)
+           nil))
+
+(assert (= (sh/sh< echo $PWD)
+           (string (os/getenv "PWD") "\n")))
+
+(assert (= (sh/sh< echo $0)
+           "sh\n"))
+
+(assert (= (sh/sh< echo `hello "world"`)
+           "hello \"world\"\n"))


### PR DESCRIPTION
Use these macros to run commands in a shell (`sh`). This allows using shell variables, `cd` and other shell builtins.

### Examples:

```janet
(import sh)

(sh/sh cd /tmp && git clone https://github.com/andrewchambers/janet-sh)

(sh/sh<
  if [ "${USER}" = ,(os/getenv "USER") ];
  then echo "it's \"me\""; else echo "not me"; fi)
```

## These things don't work:

* `(sh/sh< echo 'test')` (text in single quotes) → Use double quotes or no quotes at all.
* `(sh/sh< echo hello\ world)` (escaping spaces) → Write `(sh/sh< echo "hello world")` instead.
* `(sh/sh< echo \$PWD)` (escaping dollar signs) → Use ``(sh/sh< echo `\$PWD`)`` instead.
* Probably other things.

## To be discussed

* The new function `collect-proc-specs-subshell` is very similar (and based on) `collect-proc-specs`. Potential code duplication!?
* Might be needed for sake of completeness: `sh?`, `sh<_`, `bash`, `bash<`, `bash?`, `bash<_`!?

This addresses #21 and #22.